### PR TITLE
Support jwks fallback 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This is a middleware plugin for [Traefik](https://github.com/containous/traefik) with the following features:
 * Validation of JSON Web Tokens in cookies, headers, and/or query string parameters for access control.
-* Dynamic lookup of public keys from the well-known OpenID configuration of whitelisted issuers.
+* Dynamic lookup of public keys from the well-known OpenID configuration/jwks of whitelisted issuers.
 * Flexible claim checks, including optional wildcards and Go template interpolation.
 * Configurable HTTP redirects for unauthorized and forbidden calls for interactive requests.
 * gRPC compatibility.
@@ -19,7 +19,7 @@ experimental:
   plugins:
     jwt:
       moduleName: github.com/agilezebra/jwt-middleware
-      version: v1.2.16
+      version: v1.2.18
 ```
 1b. or with command-line options:
 
@@ -27,7 +27,7 @@ experimental:
 command:
   ...
   - "--experimental.plugins.jwt.modulename=github.com/agilezebra/jwt-middleware"
-  - "--experimental.plugins.jwt.version=v1.2.16"
+  - "--experimental.plugins.jwt.version=v1.2.18"
 ```
 
 2) Configure and activate the plugin as a middleware in your dynamic traefik config:

--- a/jwt.go
+++ b/jwt.go
@@ -597,7 +597,7 @@ func (plugin *JWTPlugin) fetchKeys(issuer string) error {
 	if err != nil {
 		// Fall back to direct JWKS URL if OpenID configuration fetch fails
 		url = issuer + ".well-known/jwks.json"
-		plugin.logInfo("failed to fetch openid-configuration from url:%s, falling back to direct JWKS URL:%s", configURL, url)
+		plugin.logInfo("failed to fetch openid-configuration from url:%s; falling back to direct JWKS URL:%s", configURL, url)
 	} else {
 		plugin.logInfo("fetched openid-configuration from url:%s", configURL)
 		url = config.JWKSURI

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -60,20 +60,20 @@ type Test struct {
 }
 
 const (
-	jwksCalls          = "jwksCalls"
-	useFixedSecret     = "useFixedSecret"
-	noAddIsser         = "noAddIsser"
-	rotateKey          = "rotateKey"
-	excludeIss         = "excludeIss"
-	configBadBody      = "configBadBody"
-	keysBadURL         = "keysBadURL"
-	keysBadBody        = "keysBadBody"
-	configServerStatus = "configServerStatus"
-	keysServerStatus   = "keysServerStatus"
-	invalidJSON        = "invalidJSON"
-	traefikURL         = "traefikURL"
-	yes                = "yes"
-	invalid            = "invalid/dummy"
+	jwksCalls             = "jwksCalls"
+	useFixedSecret        = "useFixedSecret"
+	noAddIsser            = "noAddIsser"
+	rotateKey             = "rotateKey"
+	excludeIss            = "excludeIss"
+	configBadOpenIDConfig = "configBadOpenIDConfig"
+	keysBadURL            = "keysBadURL"
+	keysBadBody           = "keysBadBody"
+	configServerStatus    = "configServerStatus"
+	keysServerStatus      = "keysServerStatus"
+	invalidJSON           = "invalidJSON"
+	traefikURL            = "traefikURL"
+	yes                   = "yes"
+	invalid               = "invalid/dummy"
 )
 
 func TestServeHTTP(tester *testing.T) {
@@ -1026,14 +1026,14 @@ func TestServeHTTP(tester *testing.T) {
 		},
 		{
 			Name:   "config bad body",
-			Expect: http.StatusUnauthorized,
+			Expect: http.StatusOK,
 			Config: `
 				require:
 					aud: test`,
 			Claims:     `{"aud": "test"}`,
 			Method:     jwt.SigningMethodES256,
 			HeaderName: "Authorization",
-			Actions:    map[string]string{configBadBody: yes},
+			Actions:    map[string]string{configBadOpenIDConfig: yes},
 		},
 		{
 			Name:   "keys bad url",
@@ -1059,7 +1059,7 @@ func TestServeHTTP(tester *testing.T) {
 		},
 		{
 			Name:   "config server internal error",
-			Expect: http.StatusUnauthorized,
+			Expect: http.StatusOK,
 			Config: `
 				require:
 					aud: test`,
@@ -1529,7 +1529,7 @@ func setup(test *Test) (http.Handler, *http.Request, *httptest.Server, error) {
 		fmt.Fprintln(response, string(payload))
 	})
 	mux.HandleFunc("/.well-known/openid-configuration", func(response http.ResponseWriter, request *http.Request) {
-		if _, ok := test.Actions[configBadBody]; ok {
+		if _, ok := test.Actions[configBadOpenIDConfig]; ok {
 			response.Header().Add("Content-Length", "1")
 			return
 		}

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -60,20 +60,20 @@ type Test struct {
 }
 
 const (
-	jwksCalls             = "jwksCalls"
-	useFixedSecret        = "useFixedSecret"
-	noAddIsser            = "noAddIsser"
-	rotateKey             = "rotateKey"
-	excludeIss            = "excludeIss"
-	configBadOpenIDConfig = "configBadOpenIDConfig"
-	keysBadURL            = "keysBadURL"
-	keysBadBody           = "keysBadBody"
-	configServerStatus    = "configServerStatus"
-	keysServerStatus      = "keysServerStatus"
-	invalidJSON           = "invalidJSON"
-	traefikURL            = "traefikURL"
-	yes                   = "yes"
-	invalid               = "invalid/dummy"
+	jwksCalls          = "jwksCalls"
+	useFixedSecret     = "useFixedSecret"
+	noAddIsser         = "noAddIsser"
+	rotateKey          = "rotateKey"
+	excludeIss         = "excludeIss"
+	configBadBody      = "configBadBody"
+	keysBadURL         = "keysBadURL"
+	keysBadBody        = "keysBadBody"
+	configServerStatus = "configServerStatus"
+	keysServerStatus   = "keysServerStatus"
+	invalidJSON        = "invalidJSON"
+	traefikURL         = "traefikURL"
+	yes                = "yes"
+	invalid            = "invalid/dummy"
 )
 
 func TestServeHTTP(tester *testing.T) {
@@ -1033,7 +1033,7 @@ func TestServeHTTP(tester *testing.T) {
 			Claims:     `{"aud": "test"}`,
 			Method:     jwt.SigningMethodES256,
 			HeaderName: "Authorization",
-			Actions:    map[string]string{configBadOpenIDConfig: yes},
+			Actions:    map[string]string{configBadBody: yes},
 		},
 		{
 			Name:   "keys bad url",
@@ -1529,7 +1529,7 @@ func setup(test *Test) (http.Handler, *http.Request, *httptest.Server, error) {
 		fmt.Fprintln(response, string(payload))
 	})
 	mux.HandleFunc("/.well-known/openid-configuration", func(response http.ResponseWriter, request *http.Request) {
-		if _, ok := test.Actions[configBadOpenIDConfig]; ok {
+		if _, ok := test.Actions[configBadBody]; ok {
 			response.Header().Add("Content-Length", "1")
 			return
 		}


### PR DESCRIPTION
Try to use {issuer}/.well-known/jwks.json when there is no working .well-known/openid-configuration